### PR TITLE
Jar filtering in history

### DIFF
--- a/src/components/History.js
+++ b/src/components/History.js
@@ -14,8 +14,11 @@ import Divider from '../css/Divider'
 import SubHeading from '../css/SubHeading'
 
 const HistoryQuery = graphql`
-  query HistoryQuery($noteFilter: NoteFilter) {
+  query HistoryQuery($userId: ID, $noteFilter: NoteFilter) {
     viewer {
+      User(id: $userId) {
+        ...HistoryNav_user
+      }
       allNotes(last: 100, orderBy: createdAt_DESC, filter: $noteFilter) @connection(key: "NoteList_allNotes", filters: []) {
         edges {
           node {
@@ -34,7 +37,8 @@ class History extends Component {
 
     this.state = {
       endDate: moment().endOf('day'),
-      interval
+      interval,
+      jarId: null
     }
   }
 
@@ -68,16 +72,26 @@ class History extends Component {
     this.setState({ interval: value })
   }
 
+  _updateJar = ({ label, value }) => {
+    this.setState({ jarId: value })
+  }
+
   render() {
     const userId = localStorage.getItem(GC_USER_ID)
     const startDate = this._getStartDate()
+    const { jarId } = this.state
 
     const variables = {
       noteFilter: {
         jar: { owner: { id: userId } },
         createdAt_gt: startDate,
         createdAt_lte: this.state.endDate
-      }
+      },
+      userId
+    }
+
+    if (jarId) {
+      variables.noteFilter.jar.id = jarId
     }
 
     const intervalOptions = [
@@ -108,6 +122,9 @@ class History extends Component {
                       margin-bottom: 1rem;
                       `}> { headers[this.state.interval] } </SubHeading>
                   <HistoryNav
+                    user={props.viewer.User}
+                    jarId={jarId}
+                    updateJar={this._updateJar}
                     setPrevInterval={this._setPrevInterval}
                     setNextInterval={this._setNextInterval}
                     updateInterval={this._updateInterval}

--- a/src/components/History.js
+++ b/src/components/History.js
@@ -30,6 +30,8 @@ const HistoryQuery = graphql`
   }
 `
 
+export const allJarsCode = 'ALL'
+
 class History extends Component {
   constructor(props) {
     super(props)
@@ -38,7 +40,7 @@ class History extends Component {
     this.state = {
       endDate: moment().endOf('day'),
       interval,
-      jarId: null
+      jarId: allJarsCode
     }
   }
 
@@ -90,7 +92,7 @@ class History extends Component {
       userId
     }
 
-    if (jarId) {
+    if (jarId !== allJarsCode) {
       variables.noteFilter.jar.id = jarId
     }
 

--- a/src/components/HistoryNav.js
+++ b/src/components/HistoryNav.js
@@ -7,6 +7,8 @@ import { css } from 'react-emotion'
 import { MdArrowBack, MdArrowForward } from "react-icons/md"
 import { SecondaryButton } from '../css/BaseButton'
 
+import { allJarsCode } from './History'
+
 const iconSize = css `
   font-size: 1rem;
 `
@@ -14,26 +16,28 @@ const iconSize = css `
 class HistoryNav extends React.Component {
   render () {
     const { interval, intervalOptions, user, jarId } = this.props
-    const jarOptions = user.jars.edges.map(({ node }) => ({ label: node.name, value: node.id }))
+    let jars = user.jars.edges.map(({ node }) => ({ label: node.name, value: node.id }))
+    const jarOptions = [{ label: 'All Jars', value: allJarsCode }, ...jars]
 
     return (
         <nav css={`
             display: flex;
             flex-direction: column;
+            align-items: center;
             `}>
-          <div css={`display: flex; justify-content: center;`}>
+          <div css={`display: flex;`}>
             <SecondaryButton onClick={this.props.setPrevInterval}>
               <MdArrowBack css={iconSize}/>
             </SecondaryButton>
             <div css={`margin: 0 1rem;`} >
-              <Dropdown options={intervalOptions} onChange={this.props.updateInterval} value={interval} />
+              <Dropdown controlClassName={css`padding: 0.5rem 1rem; min-width: 150px;`} options={intervalOptions} onChange={this.props.updateInterval} value={interval} />
             </div>
             <SecondaryButton onClick={this.props.setNextInterval}>
               <MdArrowForward css={iconSize} />
             </SecondaryButton>
           </div>
-          <div>
-            <Dropdown options={jarOptions} onChange={this.props.updateJar} value={jarId} />
+          <div css={`margin-top: 1rem; width: 100%; max-width: 300px;`}>
+            <Dropdown controlClassName={css`padding: 0.5rem 1rem;`} options={jarOptions} onChange={this.props.updateJar} value={jarId} />
           </div>
         </nav>
     )

--- a/src/components/HistoryNav.js
+++ b/src/components/HistoryNav.js
@@ -1,9 +1,10 @@
 import React from 'react'
 import Dropdown from 'react-dropdown'
+import { createFragmentContainer, graphql } from 'react-relay'
 import 'react-dropdown/style.css'
-import { MdArrowBack, MdArrowForward } from "react-icons/md"
 import { css } from 'react-emotion'
 
+import { MdArrowBack, MdArrowForward } from "react-icons/md"
 import { SecondaryButton } from '../css/BaseButton'
 
 const iconSize = css `
@@ -12,26 +13,44 @@ const iconSize = css `
 
 class HistoryNav extends React.Component {
   render () {
-    const interval = this.props.interval
-    const intervalOptions = this.props.intervalOptions
+    const { interval, intervalOptions, user, jarId } = this.props
+    const jarOptions = user.jars.edges.map(({ node }) => ({ label: node.name, value: node.id }))
 
     return (
         <nav css={`
             display: flex;
-            justify-content: center;
+            flex-direction: column;
             `}>
-          <SecondaryButton onClick={this.props.setPrevInterval}>
-            <MdArrowBack css={iconSize}/>
-          </SecondaryButton>
-          <div css={`margin: 0 1rem;`} >
-            <Dropdown options={intervalOptions} onChange={this.props.updateInterval} value={interval} />
+          <div css={`display: flex; justify-content: center;`}>
+            <SecondaryButton onClick={this.props.setPrevInterval}>
+              <MdArrowBack css={iconSize}/>
+            </SecondaryButton>
+            <div css={`margin: 0 1rem;`} >
+              <Dropdown options={intervalOptions} onChange={this.props.updateInterval} value={interval} />
+            </div>
+            <SecondaryButton onClick={this.props.setNextInterval}>
+              <MdArrowForward css={iconSize} />
+            </SecondaryButton>
           </div>
-          <SecondaryButton onClick={this.props.setNextInterval}>
-            <MdArrowForward css={iconSize} />
-          </SecondaryButton>
+          <div>
+            <Dropdown options={jarOptions} onChange={this.props.updateJar} value={jarId} />
+          </div>
         </nav>
     )
   }
 }
 
-export default HistoryNav
+export default createFragmentContainer(HistoryNav, graphql`
+  fragment HistoryNav_user on User {
+    jars(last: 100, orderBy: createdAt_DESC)
+      @connection(key: "HistoryNav_jars", filters: []) {
+      edges {
+        node {
+          id
+          name
+          description
+        }
+      }
+    }
+  }
+`)

--- a/src/components/__generated__/HistoryNav_user.graphql.js
+++ b/src/components/__generated__/HistoryNav_user.graphql.js
@@ -1,0 +1,143 @@
+/**
+ * @flow
+ */
+
+/* eslint-disable */
+
+'use strict';
+
+/*::
+import type { ConcreteFragment } from 'relay-runtime';
+import type { FragmentReference } from "relay-runtime";
+declare export opaque type HistoryNav_user$ref: FragmentReference;
+export type HistoryNav_user = {|
+  +jars: ?{|
+    +edges: ?$ReadOnlyArray<?{|
+      +node: {|
+        +id: string,
+        +name: string,
+        +description: ?string,
+      |}
+    |}>
+  |},
+  +$refType: HistoryNav_user$ref,
+|};
+*/
+
+
+const node/*: ConcreteFragment*/ = {
+  "kind": "Fragment",
+  "name": "HistoryNav_user",
+  "type": "User",
+  "metadata": {
+    "connection": [
+      {
+        "count": null,
+        "cursor": null,
+        "direction": "backward",
+        "path": [
+          "jars"
+        ]
+      }
+    ]
+  },
+  "argumentDefinitions": [],
+  "selections": [
+    {
+      "kind": "LinkedField",
+      "alias": "jars",
+      "name": "__HistoryNav_jars_connection",
+      "storageKey": null,
+      "args": null,
+      "concreteType": "JarConnection",
+      "plural": false,
+      "selections": [
+        {
+          "kind": "LinkedField",
+          "alias": null,
+          "name": "edges",
+          "storageKey": null,
+          "args": null,
+          "concreteType": "JarEdge",
+          "plural": true,
+          "selections": [
+            {
+              "kind": "LinkedField",
+              "alias": null,
+              "name": "node",
+              "storageKey": null,
+              "args": null,
+              "concreteType": "Jar",
+              "plural": false,
+              "selections": [
+                {
+                  "kind": "ScalarField",
+                  "alias": null,
+                  "name": "id",
+                  "args": null,
+                  "storageKey": null
+                },
+                {
+                  "kind": "ScalarField",
+                  "alias": null,
+                  "name": "name",
+                  "args": null,
+                  "storageKey": null
+                },
+                {
+                  "kind": "ScalarField",
+                  "alias": null,
+                  "name": "description",
+                  "args": null,
+                  "storageKey": null
+                },
+                {
+                  "kind": "ScalarField",
+                  "alias": null,
+                  "name": "__typename",
+                  "args": null,
+                  "storageKey": null
+                }
+              ]
+            },
+            {
+              "kind": "ScalarField",
+              "alias": null,
+              "name": "cursor",
+              "args": null,
+              "storageKey": null
+            }
+          ]
+        },
+        {
+          "kind": "LinkedField",
+          "alias": null,
+          "name": "pageInfo",
+          "storageKey": null,
+          "args": null,
+          "concreteType": "PageInfo",
+          "plural": false,
+          "selections": [
+            {
+              "kind": "ScalarField",
+              "alias": null,
+              "name": "hasPreviousPage",
+              "args": null,
+              "storageKey": null
+            },
+            {
+              "kind": "ScalarField",
+              "alias": null,
+              "name": "startCursor",
+              "args": null,
+              "storageKey": null
+            }
+          ]
+        }
+      ]
+    }
+  ]
+};
+// prettier-ignore
+(node/*: any*/).hash = '39509879318d12d4e2ad2f1c36e0d97b';
+module.exports = node;

--- a/src/components/__generated__/HistoryQuery.graphql.js
+++ b/src/components/__generated__/HistoryQuery.graphql.js
@@ -1,6 +1,6 @@
 /**
  * @flow
- * @relayHash 3f4f2209225ec97c6968afc0ce28bd7d
+ * @relayHash 59010683562f3383e4d8f50fc9834694
  */
 
 /* eslint-disable */
@@ -10,6 +10,7 @@
 /*::
 import type { ConcreteRequest } from 'relay-runtime';
 type EditableNote_note$ref = any;
+type HistoryNav_user$ref = any;
 export type FriendRequestStatus = "ACCEPTED" | "IGNORED" | "PENDING" | "%future added value";
 export type NoteFilter = {
   AND?: ?$ReadOnlyArray<NoteFilter>,
@@ -241,17 +242,21 @@ export type FriendRequestFilter = {
   sender?: ?UserFilter,
 };
 export type HistoryQueryVariables = {|
-  noteFilter?: ?NoteFilter
+  userId?: ?string,
+  noteFilter?: ?NoteFilter,
 |};
 export type HistoryQueryResponse = {|
   +viewer: {|
+    +User: ?{|
+      +$fragmentRefs: HistoryNav_user$ref
+    |},
     +allNotes: {|
       +edges: ?$ReadOnlyArray<?{|
         +node: {|
           +$fragmentRefs: EditableNote_note$ref
         |}
       |}>
-    |}
+    |},
   |}
 |};
 export type HistoryQuery = {|
@@ -263,9 +268,14 @@ export type HistoryQuery = {|
 
 /*
 query HistoryQuery(
+  $userId: ID
   $noteFilter: NoteFilter
 ) {
   viewer {
+    User(id: $userId) {
+      ...HistoryNav_user
+      id
+    }
     allNotes(last: 100, orderBy: createdAt_DESC, filter: $noteFilter) {
       edges {
         node {
@@ -281,6 +291,24 @@ query HistoryQuery(
       }
     }
     id
+  }
+}
+
+fragment HistoryNav_user on User {
+  jars(last: 100, orderBy: createdAt_DESC) {
+    edges {
+      node {
+        id
+        name
+        description
+        __typename
+      }
+      cursor
+    }
+    pageInfo {
+      hasPreviousPage
+      startCursor
+    }
   }
 }
 
@@ -311,26 +339,40 @@ const node/*: ConcreteRequest*/ = (function(){
 var v0 = [
   {
     "kind": "LocalArgument",
+    "name": "userId",
+    "type": "ID",
+    "defaultValue": null
+  },
+  {
+    "kind": "LocalArgument",
     "name": "noteFilter",
     "type": "NoteFilter",
     "defaultValue": null
   }
 ],
-v1 = {
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "userId",
+    "type": "ID"
+  }
+],
+v2 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "__typename",
   "args": null,
   "storageKey": null
 },
-v2 = {
+v3 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "cursor",
   "args": null,
   "storageKey": null
 },
-v3 = {
+v4 = {
   "kind": "LinkedField",
   "alias": null,
   "name": "pageInfo",
@@ -355,46 +397,56 @@ v3 = {
     }
   ]
 },
-v4 = [
-  {
-    "kind": "Variable",
-    "name": "filter",
-    "variableName": "noteFilter",
-    "type": "NoteFilter"
-  },
-  {
-    "kind": "Literal",
-    "name": "last",
-    "value": 100,
-    "type": "Int"
-  },
+v5 = {
+  "kind": "Literal",
+  "name": "last",
+  "value": 100,
+  "type": "Int"
+},
+v6 = [
+  v5,
   {
     "kind": "Literal",
     "name": "orderBy",
     "value": "createdAt_DESC",
-    "type": "NoteOrderBy"
+    "type": "JarOrderBy"
   }
 ],
-v5 = {
+v7 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "id",
   "args": null,
   "storageKey": null
 },
-v6 = {
+v8 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "name",
   "args": null,
   "storageKey": null
-};
+},
+v9 = [
+  {
+    "kind": "Variable",
+    "name": "filter",
+    "variableName": "noteFilter",
+    "type": "NoteFilter"
+  },
+  v5,
+  {
+    "kind": "Literal",
+    "name": "orderBy",
+    "value": "createdAt_DESC",
+    "type": "NoteOrderBy"
+  }
+];
 return {
   "kind": "Request",
   "operationKind": "query",
   "name": "HistoryQuery",
   "id": null,
-  "text": "query HistoryQuery(\n  $noteFilter: NoteFilter\n) {\n  viewer {\n    allNotes(last: 100, orderBy: createdAt_DESC, filter: $noteFilter) {\n      edges {\n        node {\n          ...EditableNote_note\n          id\n          __typename\n        }\n        cursor\n      }\n      pageInfo {\n        hasPreviousPage\n        startCursor\n      }\n    }\n    id\n  }\n}\n\nfragment EditableNote_note on Note {\n  id\n  text\n  createdAt\n  jar {\n    id\n    name\n    owner {\n      id\n      email\n      jars {\n        edges {\n          node {\n            id\n            name\n          }\n        }\n      }\n    }\n  }\n}\n",
+  "text": "query HistoryQuery(\n  $userId: ID\n  $noteFilter: NoteFilter\n) {\n  viewer {\n    User(id: $userId) {\n      ...HistoryNav_user\n      id\n    }\n    allNotes(last: 100, orderBy: createdAt_DESC, filter: $noteFilter) {\n      edges {\n        node {\n          ...EditableNote_note\n          id\n          __typename\n        }\n        cursor\n      }\n      pageInfo {\n        hasPreviousPage\n        startCursor\n      }\n    }\n    id\n  }\n}\n\nfragment HistoryNav_user on User {\n  jars(last: 100, orderBy: createdAt_DESC) {\n    edges {\n      node {\n        id\n        name\n        description\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      hasPreviousPage\n      startCursor\n    }\n  }\n}\n\nfragment EditableNote_note on Note {\n  id\n  text\n  createdAt\n  jar {\n    id\n    name\n    owner {\n      id\n      email\n      jars {\n        edges {\n          node {\n            id\n            name\n          }\n        }\n      }\n    }\n  }\n}\n",
   "metadata": {
     "connection": [
       {
@@ -424,6 +476,22 @@ return {
         "concreteType": "Viewer",
         "plural": false,
         "selections": [
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "User",
+            "storageKey": null,
+            "args": v1,
+            "concreteType": "User",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "FragmentSpread",
+                "name": "HistoryNav_user",
+                "args": null
+              }
+            ]
+          },
           {
             "kind": "LinkedField",
             "alias": "allNotes",
@@ -456,13 +524,13 @@ return {
                         "name": "EditableNote_note",
                         "args": null
                       },
-                      v1
+                      v2
                     ]
                   },
-                  v2
+                  v3
                 ]
               },
-              v3
+              v4
             ]
           }
         ]
@@ -486,9 +554,75 @@ return {
           {
             "kind": "LinkedField",
             "alias": null,
+            "name": "User",
+            "storageKey": null,
+            "args": v1,
+            "concreteType": "User",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "jars",
+                "storageKey": "jars(last:100,orderBy:\"createdAt_DESC\")",
+                "args": v6,
+                "concreteType": "JarConnection",
+                "plural": false,
+                "selections": [
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "edges",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "JarEdge",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "node",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "Jar",
+                        "plural": false,
+                        "selections": [
+                          v7,
+                          v8,
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "description",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          v2
+                        ]
+                      },
+                      v3
+                    ]
+                  },
+                  v4
+                ]
+              },
+              {
+                "kind": "LinkedHandle",
+                "alias": null,
+                "name": "jars",
+                "args": v6,
+                "handle": "connection",
+                "key": "HistoryNav_jars",
+                "filters": []
+              },
+              v7
+            ]
+          },
+          {
+            "kind": "LinkedField",
+            "alias": null,
             "name": "allNotes",
             "storageKey": null,
-            "args": v4,
+            "args": v9,
             "concreteType": "NoteConnection",
             "plural": false,
             "selections": [
@@ -510,7 +644,7 @@ return {
                     "concreteType": "Note",
                     "plural": false,
                     "selections": [
-                      v5,
+                      v7,
                       {
                         "kind": "ScalarField",
                         "alias": null,
@@ -534,8 +668,8 @@ return {
                         "concreteType": "Jar",
                         "plural": false,
                         "selections": [
-                          v5,
-                          v6,
+                          v7,
+                          v8,
                           {
                             "kind": "LinkedField",
                             "alias": null,
@@ -545,7 +679,7 @@ return {
                             "concreteType": "User",
                             "plural": false,
                             "selections": [
-                              v5,
+                              v7,
                               {
                                 "kind": "ScalarField",
                                 "alias": null,
@@ -580,8 +714,8 @@ return {
                                         "concreteType": "Jar",
                                         "plural": false,
                                         "selections": [
-                                          v5,
-                                          v6
+                                          v7,
+                                          v8
                                         ]
                                       }
                                     ]
@@ -592,25 +726,25 @@ return {
                           }
                         ]
                       },
-                      v1
+                      v2
                     ]
                   },
-                  v2
+                  v3
                 ]
               },
-              v3
+              v4
             ]
           },
           {
             "kind": "LinkedHandle",
             "alias": null,
             "name": "allNotes",
-            "args": v4,
+            "args": v9,
             "handle": "connection",
             "key": "NoteList_allNotes",
             "filters": []
           },
-          v5
+          v7
         ]
       }
     ]
@@ -618,5 +752,5 @@ return {
 };
 })();
 // prettier-ignore
-(node/*: any*/).hash = 'd8c6b6ba1f93fd5831f3ab279fb7e8d3';
+(node/*: any*/).hash = '505f3ed400658f21b356bf29861802ce';
 module.exports = node;


### PR DESCRIPTION
Adds filtering by jar to the history page. I realized you can center the content within the select using the controlClassName prop of `Dropdown`. Had to use a string constant as an option for 'All Jars.' 

It might be better if there were something to distinguish the two selects
![image](https://user-images.githubusercontent.com/13478407/48305523-eaad0f80-e4f9-11e8-9fec-3df6e6e6c912.png)
